### PR TITLE
修复校验位判断bug

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -118,7 +118,7 @@ trait Generator
         // 生成校验码
         $checkBit = (12 - ($bodySum % 11)) % 11;
 
-        return $checkBit == 10 ? 'X' : (string)$checkBit;
+        return $checkBit == 10 ? 'X' : (string) $checkBit;
     }
 
     /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -96,7 +96,7 @@ trait Generator
      *
      * @param string $body 身份证号 body 部分
      *
-     * @return int|string
+     * @return string
      */
     private function _generatorCheckBit($body)
     {
@@ -118,7 +118,7 @@ trait Generator
         // 生成校验码
         $checkBit = (12 - ($bodySum % 11)) % 11;
 
-        return $checkBit == 10 ? 'X' : $checkBit;
+        return $checkBit == 10 ? 'X' : (string)$checkBit;
     }
 
     /**

--- a/tests/IdValidatorTest.php
+++ b/tests/IdValidatorTest.php
@@ -30,6 +30,8 @@ class IdValidatorTest extends TestCase
         $this->assertFalse($this->idValidator->isValid('440308199902301512')); // 出生日期码不合法
         $this->assertFalse($this->idValidator->isValid('440308199901101513')); // 验证码不合法
         $this->assertFalse($this->idValidator->isValid('610104620932690'));    // 出生日期码不合法
+        $this->assertFalse($this->idValidator->isValid('11010119900307867X')); // 校验位不合法
+        $this->assertTrue($this->idValidator->isValid('110101199003078670'));
         $this->assertTrue($this->idValidator->isValid('440308199901101512'));
         $this->assertTrue($this->idValidator->isValid('500154199301135886'));
         $this->assertTrue($this->idValidator->isValid('610104620927690'));


### PR DESCRIPTION
真实校验位为0时，传入X也能通过，因为`0 == 'X'`